### PR TITLE
`watch` will json.parse passed strings. Fix #21

### DIFF
--- a/lib/micropilot.js
+++ b/lib/micropilot.js
@@ -437,7 +437,7 @@ let Micropilot = exports.Micropilot = Class({
     return this;
   },
 
-  /** (internal) watch a topic, add to `observer-service`
+  /** (internal) watch a topic, add to `observer-service`, parse json if possible
    *
    * @param {string} topic topic to watch.
    * @memberOf Micropilot
@@ -452,13 +452,28 @@ let Micropilot = exports.Micropilot = Class({
     if (this._watchfn !== undefined){
       cb = function(subject,data) that._watchfn.call(that,topic,subject,data);
     } else {
-      cb = function(subject,data) {that.record({"msg":topic,ts:Date.now(),"subject":subject,"data":data})};
+      cb = function(subject,data) {
+        // json if possible https://github.com/gregglind/micropilot/issues/21
+        try{ data = JSON.parse(data) } catch (e) {}
+        try{ subject = JSON.parse(subject) } catch (e) {}
+        that.record({"msg":topic,ts:Date.now(),"subject":subject,"data":data})
+      };
     }
     let o = observer.add(topic,cb); // add to global watch list
     this._watched[topic] = cb;
   },
 
   /** add topics to watch (non-destructive)
+    *
+    * `watch` is a simplified wrapper around `record` with these features
+    *
+    * - watch the observer service
+    * - record messages as
+    *
+    *   - `msg`: topic
+    *   - `ts`:  Date.now()
+    *   - `subject`: JSON.parse(subject) or subject
+    *   - `data`: JSON.parse(data) or data
     *
     * @param {array} watch_list list of topics
     * @return {micropilot} this

--- a/test/test-micropilot.js
+++ b/test/test-micropilot.js
@@ -82,6 +82,50 @@ exports['test watch a channel has annotated data'] = function(assert,done){
   })
 };
 
+
+exports['test watch interprets json if possible'] = function(assert,done){
+  let k = uu();
+  let mtp = Micropilot(k);
+  mtp.watch(['mtp-'+k]).start();
+  observer.notify('mtp-'+k,JSON.stringify({"a":1}));
+  observer.notify('mtp-'+k,JSON.stringify({"b":1}),JSON.stringify({"c":1}));
+  observer.notify('mtp-'+k,{test3:1},JSON.stringify({"c":1}));
+
+  mtp.unwatch();
+  mtp.data().then(function(data){
+    data.forEach(function(d){
+      ['subject','data'].forEach(function(k){
+        let t = typeof d[k];
+        assert.ok(['object','undefined'].indexOf(t) >= 0, "interpet json string correctly")
+      })
+    })
+    //jsondump(data);
+    done();
+  })
+};
+
+
+exports['test watch survives malformed json'] = function(assert,done){
+  let k = uu();
+  let mtp = Micropilot(k);
+  mtp.watch(['mtp-'+k]).start();
+  observer.notify('mtp-'+k,JSON.stringify({"b":1}).slice(2),JSON.stringify({"c":1}).slice(2));
+
+  mtp.unwatch();
+  mtp.data().then(function(data){
+    data.forEach(function(d){
+      ['subject','data'].forEach(function(k){
+        let t = typeof d[k];
+        assert.ok(['string'].indexOf(t) >= 0, "interpet json string correctly")
+      })
+    })
+    //jsondump(data);
+    done();
+  })
+};
+
+
+
 exports['test mtp watches a channel (replaced _watchfn)'] = function(assert,done){
 	let mtp = Micropilot(uu());
 	mtp._watchfn = function(topic,subject,data){mtp.unwatch(); mtp.stop(); good(assert,done)()};


### PR DESCRIPTION
`watch` continues to grow in power and 'smarts', by attempting to
`JSON.parse` subject and data.

`record` stays pure.
